### PR TITLE
feat: background alarm - notifications ring even when app is killed

### DIFF
--- a/src/__tests__/notifications.test.ts
+++ b/src/__tests__/notifications.test.ts
@@ -1,0 +1,187 @@
+import * as Notifications from 'expo-notifications';
+import {
+  cancelAlarmNotifications,
+  REPEAT_COUNT,
+  REPEAT_INTERVAL_SECONDS,
+  scheduleWakeTargetNotifications,
+} from '../services/notifications';
+import type { WakeTarget } from '../types/wake-target';
+import { DEFAULT_WAKE_TARGET } from '../types/wake-target';
+
+const mockSchedule = Notifications.scheduleNotificationAsync as jest.Mock;
+const mockCancel = Notifications.cancelScheduledNotificationAsync as jest.Mock;
+const mockGetPermissions = Notifications.getPermissionsAsync as jest.Mock;
+
+describe('notifications', () => {
+  let idCounter: number;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    idCounter = 0;
+    mockSchedule.mockImplementation(() => {
+      idCounter += 1;
+      return Promise.resolve(`notif-${idCounter}`);
+    });
+    mockGetPermissions.mockResolvedValue({ status: 'granted' });
+  });
+
+  describe('scheduleWakeTargetNotifications', () => {
+    test('schedules REPEAT_COUNT notifications per active day (7 days x 5 = 35)', async () => {
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {},
+        nextOverride: null,
+      };
+
+      const ids = await scheduleWakeTargetNotifications(target, []);
+
+      // 7 days * 5 repeats = 35
+      expect(ids).toHaveLength(7 * REPEAT_COUNT);
+      expect(mockSchedule).toHaveBeenCalledTimes(7 * REPEAT_COUNT);
+    });
+
+    test('schedules extra notifications for nextOverride (7x5 + 1x5 = 40)', async () => {
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {},
+        nextOverride: { time: { hour: 6, minute: 0 } },
+      };
+
+      const ids = await scheduleWakeTargetNotifications(target, []);
+
+      // nextOverride replaces all day times via resolveTimeForDate,
+      // so we get 7 days * 5 repeats + 1 override * 5 repeats = 40
+      expect(ids).toHaveLength(7 * REPEAT_COUNT + REPEAT_COUNT);
+      expect(mockSchedule).toHaveBeenCalledTimes(40);
+    });
+
+    test('cancels existing notifications before scheduling', async () => {
+      const existingIds = ['old-1', 'old-2', 'old-3'];
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {},
+        nextOverride: null,
+      };
+
+      await scheduleWakeTargetNotifications(target, existingIds);
+
+      expect(mockCancel).toHaveBeenCalledTimes(3);
+      expect(mockCancel).toHaveBeenCalledWith('old-1');
+      expect(mockCancel).toHaveBeenCalledWith('old-2');
+      expect(mockCancel).toHaveBeenCalledWith('old-3');
+    });
+
+    test('notification content uses alarm-notification.wav sound', async () => {
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {},
+        nextOverride: null,
+      };
+
+      await scheduleWakeTargetNotifications(target, []);
+
+      const firstCall = mockSchedule.mock.calls[0] as unknown[];
+      const callArg = firstCall[0] as { content: { sound: string } };
+      expect(callArg.content.sound).toBe('alarm-notification.wav');
+    });
+
+    test('skips days that are OFF (dayOverride type: off)', async () => {
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {
+          0: { type: 'off' }, // Sunday off
+          6: { type: 'off' }, // Saturday off
+        },
+        nextOverride: null,
+      };
+
+      const ids = await scheduleWakeTargetNotifications(target, []);
+
+      // 5 active days * 5 repeats = 25
+      expect(ids).toHaveLength(5 * REPEAT_COUNT);
+      expect(mockSchedule).toHaveBeenCalledTimes(25);
+    });
+
+    test('schedules notifications at correct 30-second intervals', async () => {
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        defaultTime: { hour: 7, minute: 0 },
+        dayOverrides: {
+          // Turn off all days except Sunday (day 0)
+          1: { type: 'off' },
+          2: { type: 'off' },
+          3: { type: 'off' },
+          4: { type: 'off' },
+          5: { type: 'off' },
+          6: { type: 'off' },
+        },
+        nextOverride: null,
+      };
+
+      await scheduleWakeTargetNotifications(target, []);
+
+      // Only Sunday active: 1 day * 5 repeats = 5
+      expect(mockSchedule).toHaveBeenCalledTimes(REPEAT_COUNT);
+
+      // Verify each call has the correct offset seconds
+      for (let i = 0; i < REPEAT_COUNT; i++) {
+        const call = mockSchedule.mock.calls[i] as unknown[];
+        const callArg = call[0] as { trigger: { second: number; hour: number; minute: number } };
+        const expectedOffset = i * REPEAT_INTERVAL_SECONDS;
+        const expectedSecond = expectedOffset % 60;
+        const expectedMinute = Math.floor(((7 * 3600 + expectedOffset) % 3600) / 60);
+        const expectedHour = Math.floor((7 * 3600 + expectedOffset) / 3600) % 24;
+        expect(callArg.trigger.second).toBe(expectedSecond);
+        expect(callArg.trigger.minute).toBe(expectedMinute);
+        expect(callArg.trigger.hour).toBe(expectedHour);
+      }
+    });
+
+    test('returns empty array when permissions not granted', async () => {
+      mockGetPermissions.mockResolvedValue({ status: 'denied' });
+      const mockRequestPermissions = Notifications.requestPermissionsAsync as jest.Mock;
+      mockRequestPermissions.mockResolvedValue({ status: 'denied' });
+
+      const target: WakeTarget = {
+        ...DEFAULT_WAKE_TARGET,
+        dayOverrides: {},
+        nextOverride: null,
+      };
+
+      const ids = await scheduleWakeTargetNotifications(target, []);
+
+      expect(ids).toHaveLength(0);
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelAlarmNotifications', () => {
+    test('cancels all given notification ids', async () => {
+      const ids = ['id-1', 'id-2', 'id-3', 'id-4'];
+
+      await cancelAlarmNotifications(ids);
+
+      expect(mockCancel).toHaveBeenCalledTimes(4);
+      expect(mockCancel).toHaveBeenCalledWith('id-1');
+      expect(mockCancel).toHaveBeenCalledWith('id-2');
+      expect(mockCancel).toHaveBeenCalledWith('id-3');
+      expect(mockCancel).toHaveBeenCalledWith('id-4');
+    });
+
+    test('handles empty array', async () => {
+      await cancelAlarmNotifications([]);
+
+      expect(mockCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('constants', () => {
+    test('REPEAT_COUNT is 5', () => {
+      expect(REPEAT_COUNT).toBe(5);
+    });
+
+    test('REPEAT_INTERVAL_SECONDS is 30', () => {
+      expect(REPEAT_INTERVAL_SECONDS).toBe(30);
+    });
+  });
+});

--- a/src/__tests__/wake-target-store.test.ts
+++ b/src/__tests__/wake-target-store.test.ts
@@ -136,4 +136,22 @@ describe('useWakeTargetStore', () => {
     expect(useWakeTargetStore.getState().target?.todos[0]?.id).toBe('todo-2');
     expect(useWakeTargetStore.getState().target?.todos[1]?.id).toBe('todo-1');
   });
+
+  test('setNotificationIds persists to AsyncStorage', async () => {
+    const ids = ['notif-1', 'notif-2', 'notif-3'];
+    await useWakeTargetStore.getState().setNotificationIds(ids);
+    expect(useWakeTargetStore.getState().notificationIds).toEqual(ids);
+    expect(mockSetItem).toHaveBeenCalledWith('notification-ids', JSON.stringify(ids));
+  });
+
+  test('loadTarget restores notificationIds from AsyncStorage', async () => {
+    const ids = ['notif-a', 'notif-b'];
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === 'wake-target') return Promise.resolve(null);
+      if (key === 'notification-ids') return Promise.resolve(JSON.stringify(ids));
+      return Promise.resolve(null);
+    });
+    await useWakeTargetStore.getState().loadTarget();
+    expect(useWakeTargetStore.getState().notificationIds).toEqual(ids);
+  });
 });


### PR DESCRIPTION
## Summary
- アプリがバックグラウンド/キル状態でもアラームが鳴り続けるようにするハイブリッド方式を実装
- 30秒のカスタム通知音 × 5回（30秒間隔）= 合計2.5分の連続通知
- アプリがBGにいる時は通知受信をトリガーに expo-av でループ再生開始
- dismiss時に残りの予定通知をキャンセル

## Changes
- `assets/sounds/alarm-notification.wav` — 30秒ループの通知音を新規作成
- `src/services/notifications.ts` — 連続通知スケジュール（REPEAT_COUNT=5, 30秒間隔）、midnight overflow対応
- `src/stores/wake-target-store.ts` — notificationIds の AsyncStorage 永続化
- `app/_layout.tsx` — BG時の即時ループ再生 + target変更時の自動再スケジュール
- `app/wakeup.tsx` — dismiss時の後続通知キャンセル + 二重再生防止
- `src/__tests__/notifications.test.ts` — 11テスト新規追加
- `src/__tests__/wake-target-store.test.ts` — 2テスト追加

## How it works

| State | Behavior |
|-------|----------|
| App foreground | Notification → expo-av loop + vibration + /wakeup screen |
| App background | Notification → expo-av loop starts (BG audio enabled) + /wakeup screen |
| App killed | 30s notification sound × 5 times (30s intervals) = 2.5 min total |

## Test plan
- [ ] 全テスト通過確認（57 tests passing）
- [ ] TypeScript型チェック通過
- [ ] Biome lint通過
- [ ] 実機テスト: アラーム設定 → BG移動 → 通知で音が鳴る
- [ ] 実機テスト: アプリキル → 通知音（30秒）が鳴る
- [ ] 実機テスト: dismiss → 後続通知が来ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)