### PR TITLE
fix: expo-dev-launcher@55.0.27 の appBridge リグレッションを回避

### DIFF
--- a/.changeset/fix-expo-dev-launcher.md
+++ b/.changeset/fix-expo-dev-launcher.md
@@ -1,0 +1,5 @@
+---
+"good-morning": patch
+---
+
+expo-dev-launcher@55.0.27 の appBridge リグレッションを回避するため 55.0.25 にピン留め

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   "pnpm": {
     "overrides": {
       "tar@<7.5.8": ">=7.5.8",
-      "expo-dev-launcher": "55.0.25"
+      "expo-dev-launcher": "55.0.25",
+      "expo-dev-menu": "55.0.22"
     },
     "patchedDependencies": {
       "expo-alarm-kit@0.1.6": "patches/expo-alarm-kit@0.1.6.patch"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   },
   "pnpm": {
     "overrides": {
-      "tar@<7.5.8": ">=7.5.8"
+      "tar@<7.5.8": ">=7.5.8",
+      "expo-dev-launcher": "55.0.25"
     },
     "patchedDependencies": {
       "expo-alarm-kit@0.1.6": "patches/expo-alarm-kit@0.1.6.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   tar@<7.5.8: '>=7.5.8'
   expo-dev-launcher: 55.0.25
+  expo-dev-menu: 55.0.22
 
 patchedDependencies:
   expo-alarm-kit@0.1.6:
@@ -2388,11 +2389,6 @@ packages:
 
   expo-dev-menu-interface@55.0.2:
     resolution: {integrity: sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==}
-    peerDependencies:
-      expo: '*'
-
-  expo-dev-menu@55.0.21:
-    resolution: {integrity: sha512-LpxEtgdnlyM5B9M3ve0fch0qlBbViTQmeS3ina54AE0SiCFoSP7k4UwxratzT7pBOuNnJ+wauhW98gmivMkdZg==}
     peerDependencies:
       expo: '*'
 
@@ -7331,7 +7327,7 @@ snapshots:
     dependencies:
       '@expo/schema-utils': 55.0.3
       expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-dev-menu: 55.0.21(expo@55.0.14)
+      expo-dev-menu: 55.0.22(expo@55.0.14)
       expo-manifests: 55.0.15(expo@55.0.14)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
@@ -7340,11 +7336,6 @@ snapshots:
   expo-dev-menu-interface@55.0.2(expo@55.0.14):
     dependencies:
       expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-
-  expo-dev-menu@55.0.21(expo@55.0.14):
-    dependencies:
-      expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-dev-menu-interface: 55.0.2(expo@55.0.14)
 
   expo-dev-menu@55.0.22(expo@55.0.14):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   tar@<7.5.8: '>=7.5.8'
+  expo-dev-launcher: 55.0.25
 
 patchedDependencies:
   expo-alarm-kit@0.1.6:
@@ -2380,13 +2381,18 @@ packages:
     peerDependencies:
       expo: '*'
 
-  expo-dev-launcher@55.0.27:
-    resolution: {integrity: sha512-V5UBfkSRFswNau4dnaHUDGt0HtRka+W+3eR1TnIqOYfDtAyT+DGxp91DY2E22ao6t1KhwhYOmQhcuvsWzgaYbg==}
+  expo-dev-launcher@55.0.25:
+    resolution: {integrity: sha512-KMM/oX+830KbxJSuF8Z2X0jGPMLmY7h/bO3h426k1XhH+N2uEvt8Nv29ZXfg9fO8y9sWzpWw+zSbxG4UelhtPA==}
     peerDependencies:
       expo: '*'
 
   expo-dev-menu-interface@55.0.2:
     resolution: {integrity: sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu@55.0.21:
+    resolution: {integrity: sha512-LpxEtgdnlyM5B9M3ve0fch0qlBbViTQmeS3ina54AE0SiCFoSP7k4UwxratzT7pBOuNnJ+wauhW98gmivMkdZg==}
     peerDependencies:
       expo: '*'
 
@@ -7312,7 +7318,7 @@ snapshots:
   expo-dev-client@55.0.26(expo@55.0.14)(typescript@5.9.3):
     dependencies:
       expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-dev-launcher: 55.0.27(expo@55.0.14)(typescript@5.9.3)
+      expo-dev-launcher: 55.0.25(expo@55.0.14)(typescript@5.9.3)
       expo-dev-menu: 55.0.22(expo@55.0.14)
       expo-dev-menu-interface: 55.0.2(expo@55.0.14)
       expo-manifests: 55.0.15(expo@55.0.14)(typescript@5.9.3)
@@ -7321,11 +7327,11 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-dev-launcher@55.0.27(expo@55.0.14)(typescript@5.9.3):
+  expo-dev-launcher@55.0.25(expo@55.0.14)(typescript@5.9.3):
     dependencies:
       '@expo/schema-utils': 55.0.3
       expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-dev-menu: 55.0.22(expo@55.0.14)
+      expo-dev-menu: 55.0.21(expo@55.0.14)
       expo-manifests: 55.0.15(expo@55.0.14)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
@@ -7334,6 +7340,11 @@ snapshots:
   expo-dev-menu-interface@55.0.2(expo@55.0.14):
     dependencies:
       expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  expo-dev-menu@55.0.21(expo@55.0.14):
+    dependencies:
+      expo: 55.0.14(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-dev-menu-interface: 55.0.2(expo@55.0.14)
 
   expo-dev-menu@55.0.22(expo@55.0.14):
     dependencies:


### PR DESCRIPTION
## Summary
- `expo-dev-launcher@55.0.27` の Xcode ビルドエラー (`property 'appBridge' not found`) を回避
- pnpm overrides で `expo-dev-launcher` を `55.0.25` にピン留め
- `expo-dev-client` は Expo 推奨の `~55.0.26` のまま維持

## 原因
expo/expo#44609 (deep link fix) で `EXDevLauncherController.h` から `appBridge` プロパティ宣言が削除されたが、`EXDevLauncherController.m` に参照が残存 → Xcode コンパイルエラー。expo/expo#44677 で追跡中。

## 削除条件
上流で `expo-dev-launcher@55.0.28+` がリリースされ修正が確認できたら、`pnpm.overrides` から `expo-dev-launcher` エントリを削除する。

## Test plan
- [ ] CI pass
- [ ] EAS Build (preview profile) が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)