### PR TITLE
feat: スクワットデバッグ画面にリアルタイムモーション情報を追加

### DIFF
--- a/.changeset/squat-debug-realtime-motion.md
+++ b/.changeset/squat-debug-realtime-motion.md
@@ -1,0 +1,14 @@
+---
+"good-morning": minor
+---
+
+スクワット動作確認画面（設定 → スクワット動作確認）にリアルタイムなモーションデバッグセクションを追加。
+
+- 加速度センサー (x, y, z, magnitude)、ジャイロ、磁気、気圧計、Pedometer の現在値をライブ表示
+- スクワット判定ステートマシンの現在フェーズ・観測 magnitude の min/max・閾値を可視化（感度調整の参考用）
+- 歩数（モーション権限取得後の watchStepCount + 今日の累計）を表示
+- 利用不可なセンサーは "Unavailable" バッジで明示
+- 各センサー値は本番フローの `useSquatDetector` とは独立購読のため、本番ロジックには一切影響しない
+
+実装に伴って `useSquatDetector` から `nextSquatPhase` / `SquatPhase` / `SQUAT_THRESHOLDS` を export し、デバッグ画面と本番フローで判定ロジックを共有するよう変更。
+Pedometer のために iOS の `NSMotionUsageDescription` を `app.config.ts` に追加。

--- a/app.config.ts
+++ b/app.config.ts
@@ -27,6 +27,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       UIBackgroundModes: ['audio', 'fetch'],
       ITSAppUsesNonExemptEncryption: false,
       NSAlarmKitUsageDescription: 'Good Morning uses alarms to wake you up at your scheduled time.',
+      // Pedometer / モーションセンサー（スクワット検出 + デバッグ画面の歩数表示）に必要。
+      // 設定 → スクワット動作確認画面で歩数や加速度をリアルタイム表示するために要求する。
+      NSMotionUsageDescription:
+        'Good Morning uses motion data to detect squats and to show real-time movement information in the squat debug screen.',
       NSSupportsLiveActivities: true,
     },
     entitlements: {

--- a/app.config.ts
+++ b/app.config.ts
@@ -27,8 +27,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       UIBackgroundModes: ['audio', 'fetch'],
       ITSAppUsesNonExemptEncryption: false,
       NSAlarmKitUsageDescription: 'Good Morning uses alarms to wake you up at your scheduled time.',
-      // Pedometer / モーションセンサー（スクワット検出 + デバッグ画面の歩数表示）に必要。
-      // 設定 → スクワット動作確認画面で歩数や加速度をリアルタイム表示するために要求する。
+      // CMPedometer (歩数) と CMAltimeter (Barometer / 気圧計) は iOS で
+      // NSMotionUsageDescription を要求する。本番フローの Accelerometer (CMMotionManager)
+      // 自体は不要だが、設定 → スクワット動作確認画面の歩数・気圧センサー表示で必須。
       NSMotionUsageDescription:
         'Good Morning uses motion data to detect squats and to show real-time movement information in the squat debug screen.',
       NSSupportsLiveActivities: true,

--- a/app/squat-check.tsx
+++ b/app/squat-check.tsx
@@ -182,6 +182,7 @@ function DebugSection({ debug }: DebugSectionProps) {
       <DebugBlock
         title={t('squatCheck.debug.pedometer.title')}
         availability={debug.pedometer.availability}
+        errorMessage={debug.pedometer.error}
       >
         <DebugRow
           label={t('squatCheck.debug.pedometer.permission')}
@@ -202,7 +203,11 @@ function DebugSection({ debug }: DebugSectionProps) {
           label={t('squatCheck.debug.pedometer.stepsSinceWatchStart')}
           value={String(debug.pedometer.stepsSinceWatchStart)}
         />
-        {debug.pedometer.error !== null && (
+        {/*
+         * available でも fetchTodaySteps が個別に失敗したケース（HealthKit 認可拒否や
+         * 7-days 制限など）はここで表示する。unavailable 時は DebugBlock 側に出る。
+         */}
+        {debug.pedometer.error !== null && debug.pedometer.availability === 'available' && (
           <DebugRow label={t('squatCheck.debug.pedometer.error')} value={debug.pedometer.error} />
         )}
       </DebugBlock>
@@ -213,10 +218,16 @@ function DebugSection({ debug }: DebugSectionProps) {
 interface DebugBlockProps {
   readonly title: string;
   readonly availability?: 'unknown' | 'available' | 'unavailable';
+  /**
+   * unavailable 時に表示したいエラーメッセージ。例外で unavailable 化したケースを
+   * デバッグするために必須。空 children と組み合わせて「unavailable だが原因は分かる」
+   * 状態を表現する。
+   */
+  readonly errorMessage?: string | null;
   readonly children: React.ReactNode;
 }
 
-function DebugBlock({ title, availability, children }: DebugBlockProps) {
+function DebugBlock({ title, availability, errorMessage, children }: DebugBlockProps) {
   const { t } = useTranslation('common');
   const showUnavailable = availability === 'unavailable';
   return (
@@ -229,7 +240,18 @@ function DebugBlock({ title, availability, children }: DebugBlockProps) {
           </Text>
         ) : null}
       </View>
-      {!showUnavailable && children}
+      {/*
+       * unavailable でも errorMessage があれば原因を表示する。これがないと
+       * 例外で unavailable 化したケース（権限取得失敗・native link 不備など）の
+       * 原因が画面から消えてしまい、デバッグ画面の意義が損なわれる。
+       */}
+      {showUnavailable ? (
+        errorMessage !== null && errorMessage !== undefined && errorMessage !== '' ? (
+          <Text style={styles.debugErrorText}>{errorMessage}</Text>
+        ) : null
+      ) : (
+        children
+      )}
     </View>
   );
 }
@@ -329,6 +351,12 @@ const styles = StyleSheet.create({
   },
   debugBadgeUnavailable: {
     color: colors.textMuted,
+  },
+  // unavailable バッジの下に出すエラー詳細。warning 色で目立たせる
+  debugErrorText: {
+    fontSize: fontSize.sm,
+    color: colors.warning,
+    lineHeight: 18,
   },
   debugRow: {
     flexDirection: 'row',

--- a/app/squat-check.tsx
+++ b/app/squat-check.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SquatChallengeItem } from '../src/components/SquatChallengeItem';
 import { borderRadius, colors, commonStyles, fontSize, spacing } from '../src/constants/theme';
+import { useMotionDebug } from '../src/hooks/useMotionDebug';
+import { SQUAT_THRESHOLDS } from '../src/hooks/useSquatDetector';
 import type { SessionTodo } from '../src/types/morning-session';
 
 /**
@@ -13,8 +15,9 @@ import type { SessionTodo } from '../src/types/morning-session';
  * まったく同じコンポーネント (SquatChallengeItem) を使い、
  * 朝のフローを発火させずに検出挙動だけを確認できるようにする。
  *
- * 設定画面からモーダル遷移で開く。動作はアラームフローと同等で、
- * SessionTodo を完全にローカル state として持ち、永続化はしない。
+ * さらに、閾値調整や「他にどんな動きが取れそうか」を検討するため、
+ * 各モーションセンサー（加速度・ジャイロ・磁気・気圧）と歩数（Pedometer）の
+ * リアルタイム値をデバッグセクションに表示する。
  */
 const REQUIRED_COUNT = 10;
 
@@ -42,6 +45,7 @@ export default function SquatCheckScreen() {
    * フック内部の state も含めて確実にリセットする。
    */
   const [resetId, setResetId] = useState(0);
+  const debug = useMotionDebug(true);
 
   const handleIncrement = useCallback((_id: string) => {
     setTodo((prev) => ({ ...prev, currentCount: (prev.currentCount ?? 0) + 1 }));
@@ -78,8 +82,184 @@ export default function SquatCheckScreen() {
       <Pressable style={styles.resetButton} onPress={handleReset}>
         <Text style={styles.resetButtonText}>{t('squatCheck.reset')}</Text>
       </Pressable>
+
+      <DebugSection debug={debug} />
     </ScrollView>
   );
+}
+
+interface DebugSectionProps {
+  readonly debug: ReturnType<typeof useMotionDebug>;
+}
+
+/**
+ * リアルタイムのセンサー値・歩数・スクワット判定状態を表示するセクション。
+ *
+ * 数値は tabular-nums + 固定小数で揃えて、サンプル毎の再描画でレイアウトが
+ * 揺れないようにする。
+ */
+function DebugSection({ debug }: DebugSectionProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <View style={[commonStyles.section, styles.debugContainer]}>
+      <Text style={styles.debugTitle}>{t('squatCheck.debug.title')}</Text>
+      <Text style={styles.debugSubtitle}>{t('squatCheck.debug.subtitle')}</Text>
+
+      {/* スクワット判定の現在状態 */}
+      <DebugBlock title={t('squatCheck.debug.squatState.title')}>
+        <DebugRow
+          label={t('squatCheck.debug.squatState.phase')}
+          value={t(`squatCheck.debug.squatState.phases.${debug.squatPhase}`)}
+        />
+        <DebugRow
+          label={t('squatCheck.debug.squatState.minMagnitude')}
+          value={fmtNum(debug.minMagnitude, 2)}
+        />
+        <DebugRow
+          label={t('squatCheck.debug.squatState.maxMagnitude')}
+          value={fmtNum(debug.maxMagnitude, 2)}
+        />
+        <DebugRow
+          label={t('squatCheck.debug.squatState.thresholds')}
+          value={`< ${SQUAT_THRESHOLDS.DESCEND_THRESHOLD} → > ${SQUAT_THRESHOLDS.RISE_THRESHOLD} → < ${SQUAT_THRESHOLDS.STANDING_THRESHOLD}`}
+        />
+      </DebugBlock>
+
+      {/* 加速度センサー */}
+      <DebugBlock
+        title={t('squatCheck.debug.accelerometer.title')}
+        availability={debug.accelerometerAvailable}
+      >
+        <DebugRow label="x" value={fmtNum(debug.accelerometer?.x, 3)} />
+        <DebugRow label="y" value={fmtNum(debug.accelerometer?.y, 3)} />
+        <DebugRow label="z" value={fmtNum(debug.accelerometer?.z, 3)} />
+        <DebugRow
+          label={t('squatCheck.debug.accelerometer.magnitude')}
+          value={fmtNum(debug.accelerometer?.magnitude, 3)}
+          highlight
+        />
+      </DebugBlock>
+
+      {/* ジャイロスコープ */}
+      <DebugBlock
+        title={t('squatCheck.debug.gyroscope.title')}
+        availability={debug.gyroscopeAvailable}
+      >
+        <DebugRow label="x" value={fmtNum(debug.gyroscope?.x, 3)} />
+        <DebugRow label="y" value={fmtNum(debug.gyroscope?.y, 3)} />
+        <DebugRow label="z" value={fmtNum(debug.gyroscope?.z, 3)} />
+      </DebugBlock>
+
+      {/* 磁気センサー */}
+      <DebugBlock
+        title={t('squatCheck.debug.magnetometer.title')}
+        availability={debug.magnetometerAvailable}
+      >
+        <DebugRow label="x" value={fmtNum(debug.magnetometer?.x, 1)} />
+        <DebugRow label="y" value={fmtNum(debug.magnetometer?.y, 1)} />
+        <DebugRow label="z" value={fmtNum(debug.magnetometer?.z, 1)} />
+      </DebugBlock>
+
+      {/* 気圧計 */}
+      <DebugBlock
+        title={t('squatCheck.debug.barometer.title')}
+        availability={debug.barometerAvailable}
+      >
+        <DebugRow
+          label={t('squatCheck.debug.barometer.pressure')}
+          value={fmtNum(debug.barometer?.pressure, 2)}
+          unit="hPa"
+        />
+        <DebugRow
+          label={t('squatCheck.debug.barometer.relativeAltitude')}
+          value={fmtNum(debug.barometer?.relativeAltitude, 2)}
+          unit="m"
+        />
+      </DebugBlock>
+
+      {/* 歩数（Pedometer / HealthKit） */}
+      <DebugBlock
+        title={t('squatCheck.debug.pedometer.title')}
+        availability={debug.pedometer.availability}
+      >
+        <DebugRow
+          label={t('squatCheck.debug.pedometer.permission')}
+          value={
+            debug.pedometer.permissionGranted === null
+              ? '—'
+              : debug.pedometer.permissionGranted
+                ? t('squatCheck.debug.pedometer.permissionGranted')
+                : t('squatCheck.debug.pedometer.permissionDenied')
+          }
+        />
+        <DebugRow
+          label={t('squatCheck.debug.pedometer.stepsToday')}
+          value={debug.pedometer.stepsToday === null ? '—' : String(debug.pedometer.stepsToday)}
+          highlight
+        />
+        <DebugRow
+          label={t('squatCheck.debug.pedometer.stepsSinceWatchStart')}
+          value={String(debug.pedometer.stepsSinceWatchStart)}
+        />
+        {debug.pedometer.error !== null && (
+          <DebugRow label={t('squatCheck.debug.pedometer.error')} value={debug.pedometer.error} />
+        )}
+      </DebugBlock>
+    </View>
+  );
+}
+
+interface DebugBlockProps {
+  readonly title: string;
+  readonly availability?: 'unknown' | 'available' | 'unavailable';
+  readonly children: React.ReactNode;
+}
+
+function DebugBlock({ title, availability, children }: DebugBlockProps) {
+  const { t } = useTranslation('common');
+  const showUnavailable = availability === 'unavailable';
+  return (
+    <View style={styles.debugBlock}>
+      <View style={styles.debugBlockHeader}>
+        <Text style={styles.debugBlockTitle}>{title}</Text>
+        {availability !== undefined && availability !== 'available' ? (
+          <Text style={[styles.debugBadge, showUnavailable && styles.debugBadgeUnavailable]}>
+            {showUnavailable ? t('squatCheck.debug.unavailable') : t('squatCheck.debug.checking')}
+          </Text>
+        ) : null}
+      </View>
+      {!showUnavailable && children}
+    </View>
+  );
+}
+
+interface DebugRowProps {
+  readonly label: string;
+  readonly value: string;
+  readonly unit?: string;
+  readonly highlight?: boolean;
+}
+
+function DebugRow({ label, value, unit, highlight }: DebugRowProps) {
+  return (
+    <View style={styles.debugRow}>
+      <Text style={styles.debugRowLabel}>{label}</Text>
+      <Text style={[styles.debugRowValue, highlight && styles.debugRowValueHighlight]}>
+        {value}
+        {unit !== undefined && <Text style={styles.debugRowUnit}>{` ${unit}`}</Text>}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * 数値を固定小数で文字列化する。null / undefined / NaN は em-dash で表す。
+ * 高頻度更新でも UI のレイアウトが揺れないよう、必ず同じ桁数で返す。
+ */
+function fmtNum(value: number | null | undefined, fractionDigits: number): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return value.toFixed(fractionDigits);
 }
 
 const styles = StyleSheet.create({
@@ -105,5 +285,72 @@ const styles = StyleSheet.create({
     color: colors.primary,
     fontSize: fontSize.md,
     fontWeight: '600',
+  },
+  debugContainer: {
+    marginTop: spacing.lg,
+  },
+  debugTitle: {
+    fontSize: fontSize.lg,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  debugSubtitle: {
+    fontSize: fontSize.sm,
+    color: colors.textMuted,
+    marginBottom: spacing.md,
+    lineHeight: 18,
+  },
+  debugBlock: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.sm,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  debugBlockHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  debugBlockTitle: {
+    fontSize: fontSize.md,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  debugBadge: {
+    fontSize: fontSize.xs,
+    color: colors.textMuted,
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 2,
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.sm,
+    overflow: 'hidden',
+  },
+  debugBadgeUnavailable: {
+    color: colors.textMuted,
+  },
+  debugRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    paddingVertical: 2,
+  },
+  debugRowLabel: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+  },
+  debugRowValue: {
+    fontSize: fontSize.sm,
+    color: colors.text,
+    fontVariant: ['tabular-nums'],
+  },
+  debugRowValueHighlight: {
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  debugRowUnit: {
+    fontSize: fontSize.xs,
+    color: colors.textMuted,
   },
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -133,20 +133,31 @@ jest.mock('expo-background-fetch', () => ({
   Status: { Available: 3, Denied: 2, Restricted: 1 },
 }));
 
-// Mock expo-sensors（useSquatDetector が DeviceMotion を使う）
-jest.mock('expo-sensors', () => ({
-  DeviceMotion: {
+// Mock expo-sensors（useSquatDetector が Accelerometer を、
+// useMotionDebug が Gyroscope/Magnetometer/Barometer/Pedometer を使う）
+jest.mock('expo-sensors', () => {
+  const buildSimpleSensor = () => ({
     isAvailableAsync: jest.fn(async () => false),
     addListener: jest.fn(() => ({ remove: jest.fn() })),
     setUpdateInterval: jest.fn(),
-    requestPermissionsAsync: jest.fn(async () => ({ status: 'granted', granted: true })),
-  },
-  Accelerometer: {
-    isAvailableAsync: jest.fn(async () => false),
-    addListener: jest.fn(() => ({ remove: jest.fn() })),
-    setUpdateInterval: jest.fn(),
-  },
-}));
+  });
+  return {
+    DeviceMotion: {
+      ...buildSimpleSensor(),
+      requestPermissionsAsync: jest.fn(async () => ({ status: 'granted', granted: true })),
+    },
+    Accelerometer: buildSimpleSensor(),
+    Gyroscope: buildSimpleSensor(),
+    Magnetometer: buildSimpleSensor(),
+    Barometer: buildSimpleSensor(),
+    Pedometer: {
+      isAvailableAsync: jest.fn(async () => false),
+      requestPermissionsAsync: jest.fn(async () => ({ status: 'granted', granted: true })),
+      getStepCountAsync: jest.fn(async () => ({ steps: 0 })),
+      watchStepCount: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  };
+});
 
 // Mock expo-constants（app/(tabs)/settings.tsx が Constants.expoConfig を読む）
 jest.mock('expo-constants', () => ({
@@ -179,5 +190,7 @@ jest.mock('react-native-svg', () => {
     G: createMockComponent('G'),
     Defs: createMockComponent('Defs'),
     ClipPath: createMockComponent('ClipPath'),
+    Circle: createMockComponent('Circle'),
+    Path: createMockComponent('Path'),
   };
 });

--- a/src/__tests__/app-screens-import.smoke.test.ts
+++ b/src/__tests__/app-screens-import.smoke.test.ts
@@ -29,6 +29,7 @@ describe('app/ screen modules — import smoke', () => {
     ['app/schedule', () => require('../../app/schedule')],
     ['app/target-edit', () => require('../../app/target-edit')],
     ['app/day-review', () => require('../../app/day-review')],
+    ['app/squat-check', () => require('../../app/squat-check')],
   ];
 
   it.each(cases)('%s loads without throwing and default-exports a function', (_name, loader) => {

--- a/src/__tests__/app-screens-render.smoke.test.tsx
+++ b/src/__tests__/app-screens-render.smoke.test.tsx
@@ -29,6 +29,7 @@ const cases: ReadonlyArray<readonly [string, () => { default: React.ComponentTyp
   ['app/schedule', () => require('../../app/schedule')],
   ['app/target-edit', () => require('../../app/target-edit')],
   ['app/day-review', () => require('../../app/day-review')],
+  ['app/squat-check', () => require('../../app/squat-check')],
 ];
 
 // 実アプリでは expo-router が NavigationContainer 経由で SafeAreaProvider を

--- a/src/__tests__/motion-debug.test.ts
+++ b/src/__tests__/motion-debug.test.ts
@@ -1,0 +1,61 @@
+/**
+ * useMotionDebug の純粋ロジック単体テスト。
+ *
+ * 背景: フック本体は センサー副作用と setState の塊で jest 環境では再現が難しい。
+ * 一方、状態遷移の計算自体は純粋関数として切り出してあるので、ここではその
+ * ロジックだけを検証する。
+ *
+ * 対象:
+ *  - nextSquatPhase: スクワット判定の状態遷移（本番フローと共有する純粋関数）
+ *  - SQUAT_THRESHOLDS: 閾値定数の値が想定通りか（デバッグ画面の表示で参照される）
+ */
+
+import { nextSquatPhase, SQUAT_THRESHOLDS, type SquatPhase } from '../hooks/useSquatDetector';
+
+describe('SQUAT_THRESHOLDS', () => {
+  it('しゃがみ → 立ち上がり → 立位の順で閾値が並んでいる', () => {
+    // 物理的に意味がある順序: しゃがむと magnitude が下がり、
+    // 立ち上がると上がり、最後に元の安静値（≈9.8）に戻る
+    expect(SQUAT_THRESHOLDS.DESCEND_THRESHOLD).toBeLessThan(SQUAT_THRESHOLDS.STANDING_THRESHOLD);
+    expect(SQUAT_THRESHOLDS.STANDING_THRESHOLD).toBeLessThan(SQUAT_THRESHOLDS.RISE_THRESHOLD);
+  });
+
+  it('デバウンス間隔は最低 500ms 以上（人間のスクワットは 1 秒以上かかる）', () => {
+    expect(SQUAT_THRESHOLDS.DEBOUNCE_MS).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe('nextSquatPhase', () => {
+  const { DESCEND_THRESHOLD, RISE_THRESHOLD, STANDING_THRESHOLD } = SQUAT_THRESHOLDS;
+
+  it('standing 状態で magnitude が DESCEND_THRESHOLD を下回ると descending に遷移', () => {
+    expect(nextSquatPhase('standing', DESCEND_THRESHOLD - 0.1)).toBe('descending');
+  });
+
+  it('standing 状態で magnitude が DESCEND_THRESHOLD 以上なら遷移しない', () => {
+    expect(nextSquatPhase('standing', DESCEND_THRESHOLD)).toBe('standing');
+    expect(nextSquatPhase('standing', 9.8)).toBe('standing');
+  });
+
+  it('descending 状態で magnitude が RISE_THRESHOLD を超えると rising に遷移', () => {
+    expect(nextSquatPhase('descending', RISE_THRESHOLD + 0.1)).toBe('rising');
+  });
+
+  it('rising 状態で magnitude が STANDING_THRESHOLD を下回ると counted（1回完了）', () => {
+    expect(nextSquatPhase('rising', STANDING_THRESHOLD - 0.1)).toBe('counted');
+  });
+
+  it('スクワット 1 回の完全なシーケンスを再現できる', () => {
+    let phase: SquatPhase = 'standing';
+    const samples = [9.8, 8.5, 8.0, 9.0, 10.8, 11.0, 9.4];
+    const transitions: Array<SquatPhase | 'counted'> = [];
+    for (const m of samples) {
+      const next = nextSquatPhase(phase, m);
+      transitions.push(next);
+      if (next !== 'counted') phase = next;
+    }
+    // 最後に counted（1 回完了）が現れる
+    expect(transitions).toContain('counted');
+    expect(transitions[transitions.length - 1]).toBe('counted');
+  });
+});

--- a/src/hooks/useMotionDebug.ts
+++ b/src/hooks/useMotionDebug.ts
@@ -2,6 +2,9 @@ import { Accelerometer, Barometer, Gyroscope, Magnetometer, Pedometer } from 'ex
 import { useEffect, useRef, useState } from 'react';
 import { nextSquatPhase, type SquatPhase } from './useSquatDetector';
 
+// biome-ignore lint/suspicious/noConsole: debug-screen hook needs visible failures for triage
+const logWarn = console.warn;
+
 /**
  * デバッグ画面（app/squat-check.tsx）でリアルタイムにモーション情報を可視化するためのフック。
  *
@@ -74,18 +77,27 @@ export interface MotionDebugState {
 const SAMPLE_INTERVAL_MS = 100;
 
 /**
- * Pedometer の今日の歩数を取得する。前回計算からの差分が大きい場合に再取得を呼ばれる。
- * シミュレータでは isAvailableAsync が true でも getStepCountAsync が失敗するため try/catch。
+ * Pedometer の今日の歩数を取得する。
+ *
+ * 失敗原因はシミュレータ・iOS の 7 days クエリ制限・ユーザー権限拒否・
+ * ネイティブブリッジの breaking change など多岐にわたる。デバッグ画面では
+ * 「— と表示されている理由」が分からないと切り分けが困難なため、エラー時は
+ * メッセージを返して呼び出し元で `pedometer.error` に反映する。
  */
-async function fetchTodaySteps(): Promise<number | null> {
+async function fetchTodaySteps(): Promise<{
+  readonly steps: number | null;
+  readonly error: string | null;
+}> {
   try {
     const start = new Date();
     start.setHours(0, 0, 0, 0);
     const end = new Date();
     const result = await Pedometer.getStepCountAsync(start, end);
-    return result.steps;
-  } catch {
-    return null;
+    return { steps: result.steps, error: null };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logWarn('[useMotionDebug] fetchTodaySteps failed:', message);
+    return { steps: null, error: message };
   }
 }
 
@@ -110,6 +122,9 @@ async function subscribeSimpleSensor<T>(
   setAvailability: (a: SensorAvailability) => void,
   onSample: (e: T) => void,
   isCancelled: () => boolean,
+  // 例外発生時のログ識別用。'available → unavailable' に潰されると native link 不備や
+  // expo-sensors の breaking change が見えなくなるため、最低限 console.warn は出す。
+  sensorLabel: string,
 ): Promise<{ remove(): void } | null> {
   try {
     const ok = await sensor.isAvailableAsync();
@@ -118,8 +133,9 @@ async function subscribeSimpleSensor<T>(
     if (!ok) return null;
     sensor.setUpdateInterval(intervalMs);
     return sensor.addListener(onSample);
-  } catch {
+  } catch (e) {
     if (!isCancelled()) setAvailability('unavailable');
+    logWarn(`[useMotionDebug] ${sensorLabel} subscription failed:`, e);
     return null;
   }
 }
@@ -128,7 +144,7 @@ async function subscribeSimpleSensor<T>(
  * Barometer サンプルを内部表現に変換する純粋関数。
  *
  * relativeAltitude は iOS のみで返ってくる optional プロパティ。
- * `'relativeAltitude' in data` でランタイム検出してから number 化する。
+ * undefined を null に正規化して、UI 側の表示判定をシンプルにする。
  */
 function buildBarometerSample(data: {
   readonly pressure: number;
@@ -195,6 +211,18 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
 
   useEffect(() => {
     if (!enabled) return;
+    // enabled が false→true に切り替わると effect が再実行されるが、ref は
+    // hook インスタンスをまたいで保持される。前回セッションの phase/min/max が
+    // 残ったまま新しいサンプルを処理すると、最初の入力で偽の遷移が起きる
+    // （例: 前回が rising のままだと最初のサンプルで即 counted）。
+    // フェーズ/min/max を初期値に戻して新セッションを始める。
+    phaseRef.current = 'standing';
+    minRef.current = null;
+    maxRef.current = null;
+    setSquatPhase('standing');
+    setMinMagnitude(null);
+    setMaxMagnitude(null);
+
     let cancelled = false;
 
     const subscriptions: Array<{ remove: () => void }> = [];
@@ -226,13 +254,14 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
     const isCancelled = () => cancelled;
 
     const setupAll = async () => {
-      const [accelSub, gyroSub, magSub, baroSub] = await Promise.all([
+      const subs = await Promise.all([
         subscribeSimpleSensor(
           Accelerometer,
           SAMPLE_INTERVAL_MS,
           setAccelerometerAvailable,
           handleAccelerometerSample,
           isCancelled,
+          'Accelerometer',
         ),
         subscribeSimpleSensor(
           Gyroscope,
@@ -240,6 +269,7 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
           setGyroscopeAvailable,
           setGyroscope,
           isCancelled,
+          'Gyroscope',
         ),
         subscribeSimpleSensor(
           Magnetometer,
@@ -247,6 +277,7 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
           setMagnetometerAvailable,
           setMagnetometer,
           isCancelled,
+          'Magnetometer',
         ),
         // 気圧変化は緩やかなので 500ms で十分
         subscribeSimpleSensor(
@@ -255,24 +286,43 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
           setBarometerAvailable,
           (data) => setBarometer(buildBarometerSample(data)),
           isCancelled,
+          'Barometer',
         ),
       ]);
-      for (const sub of [accelSub, gyroSub, magSub, baroSub]) {
+      // Promise.all を await している間に unmount されたケース（codex P2 指摘）。
+      // この時点では useEffect cleanup が既に走り終わっており、ここで push すると
+      // 永久にリスナーが残ってしまう。cancelled ならその場で remove して捨てる。
+      if (cancelled) {
+        for (const sub of subs) sub?.remove();
+        return;
+      }
+      for (const sub of subs) {
         if (sub !== null) subscriptions.push(sub);
       }
     };
 
     const startPedometerWatch = async () => {
-      // 今日の累計歩数（HealthKit 由来）。失敗しても致命的ではない
+      // 今日の累計歩数（HealthKit 由来）。失敗しても致命的ではないが、
+      // 失敗原因をデバッグ画面で見えるようにエラーは pedometer.error に反映する。
       const today = await fetchTodaySteps();
       if (cancelled) return;
-      setPedometer((p) => ({ ...p, stepsToday: today }));
+      setPedometer((p) => ({
+        ...p,
+        stepsToday: today.steps,
+        // 既存 error（例えば watch 中に出た）を today 取得失敗で上書きしない
+        error: today.error ?? p.error,
+      }));
 
-      subscriptions.push(
-        Pedometer.watchStepCount((result) => {
-          setPedometer((p) => ({ ...p, stepsSinceWatchStart: result.steps }));
-        }),
-      );
+      // watchStepCount はリスナー API。同じく Promise.all 後の race と同様、
+      // この行に来た時点で cancelled なら remove して捨てる。
+      const sub = Pedometer.watchStepCount((result) => {
+        setPedometer((p) => ({ ...p, stepsSinceWatchStart: result.steps }));
+      });
+      if (cancelled) {
+        sub.remove();
+        return;
+      }
+      subscriptions.push(sub);
     };
 
     /**
@@ -300,6 +350,7 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
         }
         await requestAndStartPedometer();
       } catch (e) {
+        logWarn('[useMotionDebug] setupPedometer failed:', e);
         if (cancelled) return;
         setPedometer((p) => ({
           ...p,
@@ -309,8 +360,11 @@ export function useMotionDebug(enabled: boolean): MotionDebugState {
       }
     };
 
-    void setupAll();
-    void setupPedometer();
+    // 各 setup 関数は内部で try/catch しているが、想定外の throw（型エラー・
+    // Promise.all の例外伝播・state setter の throw 等）が unhandled rejection に
+    // ならないよう .catch を付けて防衛する。
+    setupAll().catch((e) => logWarn('[useMotionDebug] setupAll unexpected:', e));
+    setupPedometer().catch((e) => logWarn('[useMotionDebug] setupPedometer unexpected:', e));
 
     return () => {
       cancelled = true;

--- a/src/hooks/useMotionDebug.ts
+++ b/src/hooks/useMotionDebug.ts
@@ -1,0 +1,335 @@
+import { Accelerometer, Barometer, Gyroscope, Magnetometer, Pedometer } from 'expo-sensors';
+import { useEffect, useRef, useState } from 'react';
+import { nextSquatPhase, type SquatPhase } from './useSquatDetector';
+
+/**
+ * デバッグ画面（app/squat-check.tsx）でリアルタイムにモーション情報を可視化するためのフック。
+ *
+ * 背景: スクワット検出の感度や閾値を調整したい場合、また「他にどんな動きが取れそうか」を
+ * 把握したい場合のために、端末で取得できるモーション関連データをまとめて返す。
+ * 本番フロー（useSquatDetector）とは別に独立購読しており、本番ロジックには影響しない。
+ *
+ * 各センサーは利用不可（シミュレータ・対応していない端末）の場合は null を返す。
+ * Pedometer は権限要求が必要なため `permissionGranted` で結果を表す。
+ *
+ * NOTE: このフックは毎サンプル setState を呼ぶため再描画コストが高い。
+ * デバッグ画面以外では絶対に使わないこと（本番では useSquatDetector を使う）。
+ *
+ * @param enabled - false 時は購読しない（画面遷移後のリーク防止）
+ */
+export interface MotionDebugSample {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface AccelerometerDebugSample extends MotionDebugSample {
+  readonly magnitude: number;
+}
+
+export interface BarometerDebugSample {
+  /** hPa */
+  readonly pressure: number;
+  /** 海抜からの相対高度 (m)。iOS のみ取得可能。 */
+  readonly relativeAltitude: number | null;
+}
+
+export type SensorAvailability = 'unknown' | 'available' | 'unavailable';
+
+export interface PedometerDebugState {
+  /** Pedometer ハードウェアが端末で利用可能か */
+  readonly availability: SensorAvailability;
+  /** モーション権限の状態。null = 未要求 */
+  readonly permissionGranted: boolean | null;
+  /** 監視開始からカウントしている歩数 */
+  readonly stepsSinceWatchStart: number;
+  /** 今日 0:00 から現在までの累計歩数（HealthKit 由来） */
+  readonly stepsToday: number | null;
+  /** Pedometer 利用時のエラーメッセージ */
+  readonly error: string | null;
+}
+
+export interface MotionDebugState {
+  readonly accelerometer: AccelerometerDebugSample | null;
+  readonly accelerometerAvailable: SensorAvailability;
+  readonly gyroscope: MotionDebugSample | null;
+  readonly gyroscopeAvailable: SensorAvailability;
+  readonly magnetometer: MotionDebugSample | null;
+  readonly magnetometerAvailable: SensorAvailability;
+  readonly barometer: BarometerDebugSample | null;
+  readonly barometerAvailable: SensorAvailability;
+  readonly pedometer: PedometerDebugState;
+  /** スクワット判定のステートマシン現在状態（リアルタイム） */
+  readonly squatPhase: SquatPhase;
+  /** 直近に観測された magnitude のうちの極小値（しゃがみ深さの目安） */
+  readonly minMagnitude: number | null;
+  /** 直近に観測された magnitude の極大値（立ち上がり強度の目安） */
+  readonly maxMagnitude: number | null;
+}
+
+/**
+ * デバッグ画面のサンプリング間隔。100ms は本番の useSquatDetector と同じ値。
+ * これより短くしてもセンサー側の上限に当たるため意味がない。
+ */
+const SAMPLE_INTERVAL_MS = 100;
+
+/**
+ * Pedometer の今日の歩数を取得する。前回計算からの差分が大きい場合に再取得を呼ばれる。
+ * シミュレータでは isAvailableAsync が true でも getStepCountAsync が失敗するため try/catch。
+ */
+async function fetchTodaySteps(): Promise<number | null> {
+  try {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const end = new Date();
+    const result = await Pedometer.getStepCountAsync(start, end);
+    return result.steps;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 単純センサー（Accelerometer/Gyroscope/Magnetometer/Barometer）の購読共通処理。
+ *
+ * 各センサーで try/catch・isAvailable・setUpdateInterval・addListener を繰り返し書くと
+ * 認知的複雑度が高くなるため、共通フローをここに集約している。Pedometer は API が
+ * 異なる（権限要求や watchStepCount）ため対象外。
+ *
+ * @returns 購読 subscription（unsubscribe 用）。利用不可・例外時は null。
+ */
+interface SimpleSensor<T> {
+  isAvailableAsync(): Promise<boolean>;
+  setUpdateInterval(ms: number): void;
+  addListener(cb: (e: T) => void): { remove(): void };
+}
+
+async function subscribeSimpleSensor<T>(
+  sensor: SimpleSensor<T>,
+  intervalMs: number,
+  setAvailability: (a: SensorAvailability) => void,
+  onSample: (e: T) => void,
+  isCancelled: () => boolean,
+): Promise<{ remove(): void } | null> {
+  try {
+    const ok = await sensor.isAvailableAsync();
+    if (isCancelled()) return null;
+    setAvailability(ok ? 'available' : 'unavailable');
+    if (!ok) return null;
+    sensor.setUpdateInterval(intervalMs);
+    return sensor.addListener(onSample);
+  } catch {
+    if (!isCancelled()) setAvailability('unavailable');
+    return null;
+  }
+}
+
+/**
+ * Barometer サンプルを内部表現に変換する純粋関数。
+ *
+ * relativeAltitude は iOS のみで返ってくる optional プロパティ。
+ * `'relativeAltitude' in data` でランタイム検出してから number 化する。
+ */
+function buildBarometerSample(data: {
+  readonly pressure: number;
+  readonly relativeAltitude?: number;
+}): BarometerDebugSample {
+  return {
+    pressure: data.pressure,
+    relativeAltitude: typeof data.relativeAltitude === 'number' ? data.relativeAltitude : null,
+  };
+}
+
+/**
+ * Accelerometer のサンプル毎に呼び出す純粋ステート遷移計算。
+ *
+ * setupAccelerometer 内に書くと cognitive complexity が高くなりすぎる
+ * （リスナーは I/O 副作用 + ステートマシン更新 + min/max 計算が混ざる）ため、
+ * 「次にどう状態を変えるか」だけを返すロジックをここに切り出している。
+ * `null` を返すフィールドは「変化なし → setState 不要」を意味する。
+ */
+function computeAccelerometerUpdate(
+  prevPhase: SquatPhase,
+  prevMin: number | null,
+  prevMax: number | null,
+  magnitude: number,
+): {
+  readonly nextPhase: SquatPhase | null;
+  readonly nextMin: number | null;
+  readonly nextMax: number | null;
+} {
+  const phaseResult = nextSquatPhase(prevPhase, magnitude);
+  const phaseAfterCount = phaseResult === 'counted' ? 'standing' : phaseResult;
+  return {
+    nextPhase: phaseAfterCount === prevPhase ? null : phaseAfterCount,
+    nextMin: prevMin === null || magnitude < prevMin ? magnitude : null,
+    nextMax: prevMax === null || magnitude > prevMax ? magnitude : null,
+  };
+}
+
+export function useMotionDebug(enabled: boolean): MotionDebugState {
+  const [accelerometer, setAccelerometer] = useState<AccelerometerDebugSample | null>(null);
+  const [accelerometerAvailable, setAccelerometerAvailable] =
+    useState<SensorAvailability>('unknown');
+  const [gyroscope, setGyroscope] = useState<MotionDebugSample | null>(null);
+  const [gyroscopeAvailable, setGyroscopeAvailable] = useState<SensorAvailability>('unknown');
+  const [magnetometer, setMagnetometer] = useState<MotionDebugSample | null>(null);
+  const [magnetometerAvailable, setMagnetometerAvailable] = useState<SensorAvailability>('unknown');
+  const [barometer, setBarometer] = useState<BarometerDebugSample | null>(null);
+  const [barometerAvailable, setBarometerAvailable] = useState<SensorAvailability>('unknown');
+  const [pedometer, setPedometer] = useState<PedometerDebugState>({
+    availability: 'unknown',
+    permissionGranted: null,
+    stepsSinceWatchStart: 0,
+    stepsToday: null,
+    error: null,
+  });
+  const [squatPhase, setSquatPhase] = useState<SquatPhase>('standing');
+  const [minMagnitude, setMinMagnitude] = useState<number | null>(null);
+  const [maxMagnitude, setMaxMagnitude] = useState<number | null>(null);
+
+  // フェーズはサンプル毎に参照するため ref に保持して再描画を抑える
+  const phaseRef = useRef<SquatPhase>('standing');
+  const minRef = useRef<number | null>(null);
+  const maxRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+
+    const subscriptions: Array<{ remove: () => void }> = [];
+
+    const handleAccelerometerSample = ({ x, y, z }: { x: number; y: number; z: number }) => {
+      const magnitude = Math.sqrt(x * x + y * y + z * z);
+      setAccelerometer({ x, y, z, magnitude });
+
+      const update = computeAccelerometerUpdate(
+        phaseRef.current,
+        minRef.current,
+        maxRef.current,
+        magnitude,
+      );
+      if (update.nextPhase !== null) {
+        phaseRef.current = update.nextPhase;
+        setSquatPhase(update.nextPhase);
+      }
+      if (update.nextMin !== null) {
+        minRef.current = update.nextMin;
+        setMinMagnitude(update.nextMin);
+      }
+      if (update.nextMax !== null) {
+        maxRef.current = update.nextMax;
+        setMaxMagnitude(update.nextMax);
+      }
+    };
+
+    const isCancelled = () => cancelled;
+
+    const setupAll = async () => {
+      const [accelSub, gyroSub, magSub, baroSub] = await Promise.all([
+        subscribeSimpleSensor(
+          Accelerometer,
+          SAMPLE_INTERVAL_MS,
+          setAccelerometerAvailable,
+          handleAccelerometerSample,
+          isCancelled,
+        ),
+        subscribeSimpleSensor(
+          Gyroscope,
+          SAMPLE_INTERVAL_MS,
+          setGyroscopeAvailable,
+          setGyroscope,
+          isCancelled,
+        ),
+        subscribeSimpleSensor(
+          Magnetometer,
+          SAMPLE_INTERVAL_MS,
+          setMagnetometerAvailable,
+          setMagnetometer,
+          isCancelled,
+        ),
+        // 気圧変化は緩やかなので 500ms で十分
+        subscribeSimpleSensor(
+          Barometer,
+          500,
+          setBarometerAvailable,
+          (data) => setBarometer(buildBarometerSample(data)),
+          isCancelled,
+        ),
+      ]);
+      for (const sub of [accelSub, gyroSub, magSub, baroSub]) {
+        if (sub !== null) subscriptions.push(sub);
+      }
+    };
+
+    const startPedometerWatch = async () => {
+      // 今日の累計歩数（HealthKit 由来）。失敗しても致命的ではない
+      const today = await fetchTodaySteps();
+      if (cancelled) return;
+      setPedometer((p) => ({ ...p, stepsToday: today }));
+
+      subscriptions.push(
+        Pedometer.watchStepCount((result) => {
+          setPedometer((p) => ({ ...p, stepsSinceWatchStart: result.steps }));
+        }),
+      );
+    };
+
+    /**
+     * Pedometer の権限要求 → 状態反映 → watch 開始までの 1 連の処理。
+     * 利用可能な前提で呼ばれる（呼び出し元で isAvailableAsync 済み）。
+     */
+    const requestAndStartPedometer = async () => {
+      const perm = await Pedometer.requestPermissionsAsync();
+      if (cancelled) return;
+      setPedometer((p) => ({
+        ...p,
+        availability: 'available',
+        permissionGranted: perm.granted,
+      }));
+      if (perm.granted) await startPedometerWatch();
+    };
+
+    const setupPedometer = async () => {
+      try {
+        const available = await Pedometer.isAvailableAsync();
+        if (cancelled) return;
+        if (!available) {
+          setPedometer((p) => ({ ...p, availability: 'unavailable' }));
+          return;
+        }
+        await requestAndStartPedometer();
+      } catch (e) {
+        if (cancelled) return;
+        setPedometer((p) => ({
+          ...p,
+          availability: 'unavailable',
+          error: e instanceof Error ? e.message : String(e),
+        }));
+      }
+    };
+
+    void setupAll();
+    void setupPedometer();
+
+    return () => {
+      cancelled = true;
+      for (const sub of subscriptions) sub.remove();
+    };
+  }, [enabled]);
+
+  return {
+    accelerometer,
+    accelerometerAvailable,
+    gyroscope,
+    gyroscopeAvailable,
+    magnetometer,
+    magnetometerAvailable,
+    barometer,
+    barometerAvailable,
+    pedometer,
+    squatPhase,
+    minMagnitude,
+    maxMagnitude,
+  };
+}

--- a/src/hooks/useSquatDetector.ts
+++ b/src/hooks/useSquatDetector.ts
@@ -9,23 +9,35 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * 端末の向きに依存しないよう、3軸の合成加速度（magnitude）を使用する。
  * 静止時は約 9.8 m/s²、しゃがむと一時的に減少し、立ち上がると増加する。
  */
-type SquatPhase = 'standing' | 'descending' | 'rising';
+export type SquatPhase = 'standing' | 'descending' | 'rising';
 
-// 3軸合成加速度の閾値。
-// 静止時の magnitude ≈ 9.8。しゃがむと < 9.0、立ち上がると > 10.5 程度になる。
-const DESCEND_THRESHOLD = 9.0;
-const RISE_THRESHOLD = 10.5;
-const STANDING_THRESHOLD = 9.5;
-/** 連続検出を防ぐ最小間隔（ms）。人間のスクワット1回は最低でも1秒以上かかる。 */
-const DEBOUNCE_MS = 800;
+/**
+ * 3軸合成加速度の閾値。
+ * 静止時の magnitude ≈ 9.8。しゃがむと < 9.0、立ち上がると > 10.5 程度になる。
+ *
+ * デバッグ画面（app/squat-check.tsx の useMotionDebug）から参照して
+ * リアルタイムの値と並べて表示するため export している。値を変えると
+ * 本番フローとデバッグ表示の両方に反映される（意図的に同じ閾値を共有）。
+ */
+export const SQUAT_THRESHOLDS = {
+  DESCEND_THRESHOLD: 9.0,
+  RISE_THRESHOLD: 10.5,
+  STANDING_THRESHOLD: 9.5,
+  /** 連続検出を防ぐ最小間隔（ms）。人間のスクワット1回は最低でも1秒以上かかる。 */
+  DEBOUNCE_MS: 800,
+} as const;
+
+const { DESCEND_THRESHOLD, RISE_THRESHOLD, STANDING_THRESHOLD, DEBOUNCE_MS } = SQUAT_THRESHOLDS;
 
 /**
  * 加速度の magnitude と現在のフェーズから次のフェーズを決定する純粋関数。
  * useEffect 内のコールバックから切り出すことで認知複雑度を下げている。
  *
+ * デバッグ画面（useMotionDebug）でも同じ判定を再現するため export している。
+ *
  * @returns 新しいフェーズ。'counted' は1回のスクワット完了を意味する。
  */
-function nextPhase(phase: SquatPhase, magnitude: number): SquatPhase | 'counted' {
+export function nextSquatPhase(phase: SquatPhase, magnitude: number): SquatPhase | 'counted' {
   if (phase === 'standing' && magnitude < DESCEND_THRESHOLD) {
     return 'descending';
   }
@@ -77,7 +89,7 @@ export function useSquatDetector(
 
     const subscription = Accelerometer.addListener(({ x, y, z }) => {
       const magnitude = Math.sqrt(x * x + y * y + z * z);
-      const result = nextPhase(phaseRef.current, magnitude);
+      const result = nextSquatPhase(phaseRef.current, magnitude);
 
       if (result === 'counted') {
         const now = Date.now();

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -67,6 +67,48 @@
   "squatCheck": {
     "title": "Squat Check",
     "description": "Verify the squat detection using the exact same logic that runs when dismissing your alarm. Hold your device and try a real squat.",
-    "reset": "Reset"
+    "reset": "Reset",
+    "debug": {
+      "title": "Live motion data",
+      "subtitle": "Real-time sensor values used (or potentially usable) for movement detection. Use this to tune thresholds or imagine new task types.",
+      "unavailable": "Unavailable",
+      "checking": "Checking…",
+      "squatState": {
+        "title": "Squat detector state",
+        "phase": "Phase",
+        "minMagnitude": "Min magnitude (descend)",
+        "maxMagnitude": "Max magnitude (rise)",
+        "thresholds": "Thresholds (m/s²)",
+        "phases": {
+          "standing": "standing",
+          "descending": "descending",
+          "rising": "rising"
+        }
+      },
+      "accelerometer": {
+        "title": "Accelerometer (m/s²)",
+        "magnitude": "magnitude"
+      },
+      "gyroscope": {
+        "title": "Gyroscope (rad/s)"
+      },
+      "magnetometer": {
+        "title": "Magnetometer (µT)"
+      },
+      "barometer": {
+        "title": "Barometer",
+        "pressure": "pressure",
+        "relativeAltitude": "relative altitude"
+      },
+      "pedometer": {
+        "title": "Pedometer / Steps",
+        "permission": "Motion permission",
+        "permissionGranted": "Granted",
+        "permissionDenied": "Denied",
+        "stepsToday": "Steps today",
+        "stepsSinceWatchStart": "Steps since opened",
+        "error": "Error"
+      }
+    }
   }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -67,6 +67,48 @@
   "squatCheck": {
     "title": "スクワット動作確認",
     "description": "アラーム解除時と同じ検出ロジックで動作を確認できます。端末を持って実際にスクワットしてみてください。",
-    "reset": "リセット"
+    "reset": "リセット",
+    "debug": {
+      "title": "リアルタイムモーション情報",
+      "subtitle": "動作検出に使われている、あるいは使える可能性のあるセンサー値。閾値の調整や新しいタスクの発想に使ってください。",
+      "unavailable": "利用不可",
+      "checking": "確認中…",
+      "squatState": {
+        "title": "スクワット判定の状態",
+        "phase": "フェーズ",
+        "minMagnitude": "最小magnitude (しゃがみ深さ)",
+        "maxMagnitude": "最大magnitude (立ち上がり)",
+        "thresholds": "閾値 (m/s²)",
+        "phases": {
+          "standing": "立位",
+          "descending": "下降中",
+          "rising": "上昇中"
+        }
+      },
+      "accelerometer": {
+        "title": "加速度センサー (m/s²)",
+        "magnitude": "合成加速度"
+      },
+      "gyroscope": {
+        "title": "ジャイロスコープ (rad/s)"
+      },
+      "magnetometer": {
+        "title": "磁気センサー (µT)"
+      },
+      "barometer": {
+        "title": "気圧計",
+        "pressure": "気圧",
+        "relativeAltitude": "相対高度"
+      },
+      "pedometer": {
+        "title": "歩数 (Pedometer / ヘルスケア)",
+        "permission": "モーション権限",
+        "permissionGranted": "許可済み",
+        "permissionDenied": "未許可",
+        "stepsToday": "今日の歩数",
+        "stepsSinceWatchStart": "画面を開いてからの歩数",
+        "error": "エラー"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- 設定 → スクワット動作確認画面に **Live motion data** デバッグセクションを追加。加速度・ジャイロ・磁気・気圧計・歩数 (Pedometer) のリアルタイム値、スクワット判定ステートマシンの現在フェーズ・観測 magnitude の min/max・閾値を一覧表示する。
- `useMotionDebug` フックを新規追加。本番フロー (`useSquatDetector`) とは独立購読のため、本番のスクワット検出ロジックには影響しない。デバッグ画面と本番フローで同じ判定ロジックを共有するため `nextSquatPhase` / `SQUAT_THRESHOLDS` / `SquatPhase` を `useSquatDetector` から export。
- Pedometer 利用のため iOS の `NSMotionUsageDescription` を `app.config.ts` に追加。jest mock に Pedometer/Gyroscope/Magnetometer/Barometer と Svg `Circle`/`Path` を追加し、`squat-check` 画面を import/render スモークテストにも追加。
- 純粋関数 `nextSquatPhase` / `SQUAT_THRESHOLDS` の単体テスト (`motion-debug.test.ts`) を追加。

## Background

スクワット判定の感度調整や、「他にどんな動きが取れそうか」(歩数・気圧変化・回転など) を発想するためには、本番フローを発火させずに **生データを目で見られる場所** が必要だった。
従来の `app/squat-check.tsx` は SquatChallengeItem を再現するだけだったため、「なぜカウントされない/されすぎるのか」を切り分けられなかった。今回の追加で magnitude の min/max が見えるようになり、閾値 (DESCEND/RISE/STANDING) と並べて評価できる。

## Related

- 起床タスクの選択肢追加 issue: #76 (「外の写真を撮る」)

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm lint` pass
- [x] `pnpm biome format .` pass
- [x] `pnpm test` (24 suites / 314 tests) pass
- [x] `npx expo install --check` pass
- [x] `pnpm bundle:check` (Metro export) pass
- [x] `pnpm changeset status --since=origin/main` で minor bump 認識
- [ ] 実機で設定 → スクワット動作確認を開き、各センサー値がリアルタイムに更新されるか確認
- [ ] 実機で Motion 権限ダイアログが正しく出るか確認（NSMotionUsageDescription）
- [ ] 実機でスクワットを 1 回行い、加速度 magnitude の min/max とフェーズ遷移が想定通り表示されるか
- [ ] シミュレータで利用不可センサーが "Unavailable" バッジで表示されるか確認

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2MyYKuojw7e9VuNvqUWJh)_