### PR TITLE
fix: Changesets Version PR で changeset-check を誤爆させない

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -14,6 +14,9 @@ jobs:
   check:
     name: Check for changeset
     runs-on: ubuntu-latest
+    # changesets/action が作る Version PR は既存 changeset を消費するのが目的で、
+    # 新規 changeset が無いのが正常な状態のため対象から除外する。
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `changesets/action` が作る "Version Packages" PR (`changeset-release/main` ブランチ) は既存 changeset を消費してバージョンを上げるためのものであり、新規 changeset が存在しないのが正常な状態
- `Changeset Check` ワークフローがこのケースも対象にしてしまい、`pnpm changeset status --since=origin/main` が「変更があるのに changeset がない」と誤検知して失敗していた（[該当 run](https://github.com/tktcorporation/good-morning/actions/runs/28763888680/job/85284291654?pr=83)）
- `changeset-release/main` ブランチからの PR を `Check for changeset` ジョブの対象から除外

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm biome format .`
- [x] `pnpm test`
- [x] `npx expo install --check`
- [x] `pnpm changeset status --since=origin/main`


---
_Generated by [Claude Code](https://claude.ai/code/session_01L6NgvU9R5ZcsPbJ5DsfGqM)_